### PR TITLE
2026 01 12 fix deployment bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ And in the other, run:
 ```julia
 using DocumenterVitepress
 
-DocumenterVitepress.dev_docs("build"; md_output_path="")
+DocumenterVitepress.dev_docs("build")
 ```
 
 Open the LocalHost Url spawned by the vitepress process

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,7 +10,7 @@ makedocs(
     draft = false,
     # TODO expand (https://github.com/SciML/SciMLDocs/blob/0fa5c9c43cf768588124861e76c7854e671ad9d7/docs/make.jl#L29C1-L29C63)
     format = DocumenterVitepress.MarkdownVitepress(
-        repo = "https://github.com/BioJulia/BioJuliaDocs",
+        repo = "/github.com/BioJulia/BioJuliaDocs",
     ),
     pages = [
         "Getting Started" => [
@@ -34,8 +34,8 @@ makedocs(
     ]
 )
 
-DocumenterVitepress.deploydocs(
-    repo = "github.com/BioJulia/BioJuliaDocs.git",
+deploydocs(
+    repo = "https://github.com/BioJulia/BioJuliaDocs.git",
     target = "build",
     devbranch = "main",
     branch = "gh-pages",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -34,8 +34,8 @@ makedocs(
     ]
 )
 
-deploydocs(
-    repo = "https://github.com/BioJulia/BioJuliaDocs.git",
+DocumenterVitepress.deploydocs(
+    repo = "github.com/BioJulia/BioJuliaDocs.git",
     target = "build",
     devbranch = "main",
     branch = "gh-pages",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,7 +10,7 @@ makedocs(
     draft = false,
     # TODO expand (https://github.com/SciML/SciMLDocs/blob/0fa5c9c43cf768588124861e76c7854e671ad9d7/docs/make.jl#L29C1-L29C63)
     format = DocumenterVitepress.MarkdownVitepress(
-        repo = "/github.com/BioJulia/BioJuliaDocs",
+        repo = "https://github.com/BioJulia/BioJuliaDocs",
     ),
     pages = [
         "Getting Started" => [


### PR DESCRIPTION
I was playing around with different variables in `make.jl` to try to fix the deployment problem. I was testing out the changes by deploying the website locally. However, I noticed that once the hardcoding of `md_output_path=""`  was removed from the deployment function, the website was generated correctly (it looks like issues with defining where the output file is generated has caused us trouble in the past https://github.com/BioJulia/BioJuliaDocs/pull/23/files) . Can we try merging this PR in and seeing if the website still fails to deploy correctly? If so, I think the next thing will be to investigate how Github is publishing the site, as it works locally. 

<img width="1483" height="905" alt="image" src="https://github.com/user-attachments/assets/3468a199-3fc1-4e05-aef7-64d510a4fcc9" />

The Vitepress documentation does not explicitly set `md_output_path` in its example. https://luxdl.github.io/DocumenterVitepress.jl/stable/manual/documenter_to_vitepress_docs_example 



