### PR TITLE
add write permissions for DocCleanup.yml

### DIFF
--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -2,15 +2,18 @@
 name: Doc Preview Cleanup
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+
+permissions:
+  contents: write
 
 jobs:
   doc-preview-cleanup:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
       - name: Delete preview and history + push changes


### PR DESCRIPTION
All pull-requests merged in this year have failed due to the following error:

```
fatal: unable to access 'https://github.com/BioJulia/BioJuliaDocs/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

See [here](https://github.com/BioJulia/BioJuliaDocs/actions/runs/20863625821/job/59949180074) for more evidence. 

It looks like to me that the bug is related to Github not having the correct permissions. Or perhaps a token has expired. Unfortunately, I don't have a way to test the solution besides merging this PR (it needs 1 approving review). If. there's another way to test Github Actions, please let me know. 

