### PR TITLE
Fix 404s on outbound biojulia.dev links 

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,7 +22,7 @@ hero:
 
 <div class="VPFeatures">
   <div class="VPFeature">
-    <a href="https://biojulia.dev/BioTutorials/dev/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioTutorials/dev/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioTutorials</h3>
         <p class="details">These are still a work in progress</p>
@@ -44,7 +44,7 @@ hero:
 
 <div class="VPFeatures" id="packages-grid">
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/TwoBit.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/TwoBit.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">TwoBit.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write 2bit sequence files</p>
@@ -53,7 +53,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/Automa.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/Automa.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">Automa.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Efficient state-machine generation to quickly and correctly parse bespoke file formats</p>
@@ -62,7 +62,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/BED.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BED.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BED.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write BED format files</p>
@@ -71,7 +71,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/BGZFLib.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BGZFLib.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BGZFLib.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Low-level BGZF compression library</p>
@@ -80,7 +80,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://github.com/BioJulia/BGZFStreams.jl" class="feature-link">
+    <a href="https://github.com/BioJulia/BGZFStreams.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BGZFStreams.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write BGZF compressed files</p>
@@ -89,7 +89,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/BigWig.jl/dev/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BigWig.jl/dev/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BigWig.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write BigWig format files</p>
@@ -98,7 +98,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/BioAlignments.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioAlignments.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioAlignments.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Sequence alignment algorithms and data structures</p>
@@ -107,7 +107,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="other">
-    <a href="https://biojulia.dev/BioGenerics.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioGenerics.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioGenerics.jl <span class="feature-badge badge-other">Other</span></h3>
         <p class="details">Generic interface definitions for BioJulia packages</p>
@@ -116,7 +116,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/BioMakie.jl/dev/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioMakie.jl/dev/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioMakie.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Visualize sequences and 3D proteins with ease</p>
@@ -125,7 +125,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/BioMarkovChains.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioMarkovChains.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioMarkovChains.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Markov chain models for biological sequences</p>
@@ -134,7 +134,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/BioSequences.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioSequences.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioSequences.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Optimized types for working with biological sequences (eg DNA, RNA, proteins)</p>
@@ -143,7 +143,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="other">
-    <a href="https://biojulia.dev/BioServices.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioServices.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioServices.jl <span class="feature-badge badge-other">Other</span></h3>
         <p class="details">Interface to biological web services and databases</p>
@@ -152,7 +152,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/BioStructures.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioStructures.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioStructures.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Read, write, and manipulate macromolecular structures (PDB, mmCIF)</p>
@@ -161,7 +161,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/BioSymbols.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BioSymbols.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioSymbols.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Primitive types for nucleotides and amino acids</p>
@@ -170,7 +170,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="io">
-    <a href="https://biojulia.dev/BufferIO.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/BufferIO.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BufferIO.jl <span class="feature-badge badge-io">I/O</span></h3>
         <p class="details">IO interface for buffer operations</p>
@@ -179,7 +179,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/CIGARStrings.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/CIGARStrings.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">CIGARStrings.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Parse and manipulate CIGAR strings for sequence alignments</p>
@@ -188,7 +188,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="outside">
-    <a href="https://ecojulia.org" class="feature-link">
+    <a href="https://ecojulia.org" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">EcoJulia <span class="feature-badge badge-outside">Outside Org</span></h3>
         <p class="details">Ecological modeling and analysis ecosystem</p>
@@ -196,7 +196,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/FASTX.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/FASTX.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">FASTX.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write FASTA and FASTQ files</p>
@@ -205,7 +205,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="other">
-    <a href="https://github.com/BioJulia/FormatSpecimens.jl" class="feature-link">
+    <a href="https://github.com/BioJulia/FormatSpecimens.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">FormatSpecimens.jl <span class="feature-badge badge-other">Other</span></h3>
         <p class="details">Test specimens for biological file formats</p>
@@ -214,7 +214,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/GeneticVariation.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/GeneticVariation.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">GeneticVariation.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Types and methods for working with genetic variation data</p>
@@ -223,7 +223,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/GenomicAnnotations.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/GenomicAnnotations.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">GenomicAnnotations.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Read and write genomic annotations (GFF3, GenBank, EMBL)</p>
@@ -232,7 +232,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/GenomicFeatures.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/GenomicFeatures.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">GenomicFeatures.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Genomic interval operations and data structures</p>
@@ -241,7 +241,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/GFF3.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/GFF3.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">GFF3.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write GFF3 format files</p>
@@ -250,7 +250,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://github.com/BioJulia/GraphicalFragmentAssembly.jl" class="feature-link">
+    <a href="https://github.com/BioJulia/GraphicalFragmentAssembly.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">GraphicalFragmentAssembly.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write GFA format for sequence graphs</p>
@@ -259,7 +259,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="other">
-    <a href="https://biojulia.dev/IntervalTrees.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/IntervalTrees.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">IntervalTrees.jl <span class="feature-badge badge-other">Other</span></h3>
         <p class="details">Efficient interval tree data structures</p>
@@ -268,7 +268,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="outside">
-    <a href="https://juliahealth.org" class="feature-link">
+    <a href="https://juliahealth.org" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">JuliaHealth <span class="feature-badge badge-outside">Outside Org</span></h3>
         <p class="details">Health and medical informatics packages</p>
@@ -276,7 +276,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/KmerAnalysis.jl/dev/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/KmerAnalysis.jl/dev/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">KmerAnalysis.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">K-mer counting and analysis tools</p>
@@ -285,7 +285,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/Kmers.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/Kmers.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">Kmers.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Efficient k-mer representation and operations</p>
@@ -294,7 +294,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="other">
-    <a href="https://github.com/BioJulia/KWayMerges.jl" class="feature-link">
+    <a href="https://github.com/BioJulia/KWayMerges.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">KWayMerges.jl <span class="feature-badge badge-other">Other</span></h3>
         <p class="details">K-way merge algorithms for sorted iterators</p>
@@ -303,7 +303,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="io">
-    <a href="https://biojulia.dev/MemoryViews.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/MemoryViews.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">MemoryViews.jl <span class="feature-badge badge-io">I/O</span></h3>
         <p class="details">Efficient memory views for IO operations</p>
@@ -312,7 +312,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://github.com/BioJulia/MMTF.jl" class="feature-link">
+    <a href="https://github.com/BioJulia/MMTF.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">MMTF.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write MMTF macromolecular structure files</p>
@@ -321,7 +321,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://github.com/BioJulia/NCBIBlast.jl" class="feature-link">
+    <a href="https://github.com/BioJulia/NCBIBlast.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">NCBIBlast.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Interface to NCBI BLAST+ for sequence similarity searches</p>
@@ -330,7 +330,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="outside">
-    <a href="https://openmendel.github.io" class="feature-link">
+    <a href="https://openmendel.github.io" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">OpenMendel <span class="feature-badge badge-outside">Outside Org</span></h3>
         <p class="details">Statistical genetics and genomic analysis tools</p>
@@ -338,7 +338,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/PairwiseMappingFormat.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/PairwiseMappingFormat.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">PairwiseMappingFormat.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write PAF alignment format</p>
@@ -347,7 +347,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/PopGen.jl" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/PopGen.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">PopGen.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Population genetics analysis and simulation</p>
@@ -356,7 +356,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://github.com/BioJulia/PopGenCore.jl" class="feature-link">
+    <a href="https://github.com/BioJulia/PopGenCore.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">PopGenCore.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Core types and functions for population genetics</p>
@@ -365,7 +365,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/ProteinSecondaryStructures.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/ProteinSecondaryStructures.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">ProteinSecondaryStructures.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Analyze and predict protein secondary structures</p>
@@ -374,7 +374,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/ReadDatastores.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/ReadDatastores.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">ReadDatastores.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Efficient storage and access for sequencing read data</p>
@@ -383,7 +383,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/SequenceVariation.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/SequenceVariation.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">SequenceVariation.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Represent and manipulate sequence variations (mutations, variants)</p>
@@ -392,7 +392,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/SingleCellProjections.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/SingleCellProjections.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">SingleCellProjections.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">More cells? No Problem! Get UMAPs and other projections of your single cell data using the power of Sparse Matrices</p>
@@ -401,7 +401,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="bioinformatics">
-    <a href="https://biojulia.dev/SubstitutionModels.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/SubstitutionModels.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">SubstitutionModels.jl <span class="feature-badge badge-bioinformatics">Bioinformatics</span></h3>
         <p class="details">Nucleotide and amino acid substitution models for phylogenetics</p>
@@ -410,7 +410,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="other">
-    <a href="https://github.com/BioJulia/WaveletMatrices.jl" class="feature-link">
+    <a href="https://github.com/BioJulia/WaveletMatrices.jl" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">WaveletMatrices.jl <span class="feature-badge badge-other">Other</span></h3>
         <p class="details">Wavelet matrix data structure for fast queries</p>
@@ -419,7 +419,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/XAM.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/XAM.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">XAM.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Read and write SAM and BAM files</p>
@@ -428,7 +428,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature" data-category="files">
-    <a href="https://biojulia.dev/XAMAuxData.jl/stable/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/XAMAuxData.jl/stable/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">XAMAuxData.jl <span class="feature-badge badge-files">Files</span></h3>
         <p class="details">Auxiliary data handling for SAM/BAM files</p>
@@ -442,7 +442,7 @@ hero:
 
 <div class="VPFeatures">
   <div class="VPFeature">
-    <a href="https://biojulia.dev/posts/" class="feature-link" rel="external">
+    <a href="https://biojulia.dev/posts/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioJulia Blog</h3>
         <p class="details">Stay up to date with the latest news, tutorials, and community updates</p>
@@ -450,7 +450,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature">
-    <a href="https://julialang.org/slack/" class="feature-link">
+    <a href="https://julialang.org/slack/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">Julia Slack</h3>
         <p class="details">Chat with the Julia community on Slack</p>
@@ -458,7 +458,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature">
-    <a href="https://discourse.julialang.org/" class="feature-link">
+    <a href="https://discourse.julialang.org/" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">Julia Discourse</h3>
         <p class="details">Ask questions and discuss with the Julia community</p>
@@ -466,7 +466,7 @@ hero:
     </a>
   </div>
   <div class="VPFeature">
-    <a href="https://github.com/BioJulia/biojulia.github.io/blob/main/CONTRIBUTING.md" class="feature-link" rel="external">
+    <a href="https://github.com/BioJulia/biojulia.github.io/blob/main/CONTRIBUTING.md" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">Contributing to BioJulia</h3>
         <p class="details">Learn how to contribute to BioJulia packages</p>


### PR DESCRIPTION
Clicking links from https://biojulia.dev/dev/ to other sites hosted on the same domain (e.g. https://biojulia.dev/BioTutorials/dev/, https://biojulia.dev/TwoBit.jl/stable/) shows a 404 page until a refresh. This happens because the VitePress client router navigates to these links within the  https://biojulia.dev/dev. However, these links don't have the `/dev` at the end of their URL (this is just added to the biojulia website during deployment)

This PR updates the external “feature card” links on the homepage (`docs/src/index.md`) to use `target="_blank"` and `rel="noopener noreferrer"`, bypassing the VitePress router and ensuring the browser performs a real navigation. This makes sure that a new webpage is opened, rather than just navigating within `https://biojulia.dev/dev/ `. `rel="noopener noreferrer" `also prevents window.opener access for security. This prevents a user from clicking back. This isn't inherently related to the problem, but this is a common pattern that people use.

The old solution that was merged in (`rel="external"`) didn't work. While this tells VitePress that the website is an external website, this is a piece of metadata. It doesn't tell Vitepress to change how it handles opening the link. 