### PR TITLE
Fix BioTutorials link (remove /dev/ suffix)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,7 +22,7 @@ hero:
 
 <div class="VPFeatures">
   <div class="VPFeature">
-    <a href="https://biojulia.dev/BioTutorials/dev/" class="feature-link" target="_blank" rel="noopener noreferrer">
+    <a href="https://biojulia.dev/BioTutorials" class="feature-link" target="_blank" rel="noopener noreferrer">
       <article class="box">
         <h3 class="title">BioTutorials</h3>
         <p class="details">These are still a work in progress</p>


### PR DESCRIPTION
Fixed broken link to BioTutorials that was causing a 404 error.

## Problem
The link `https://biojulia.dev/BioTutorials/dev/` returns a 404 error.

## Solution
Removed the `/dev/` suffix from the URL.

Closes #37

---

If this PR helped your project, tips are appreciated! 🙏
USDT (TRC20): `TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`